### PR TITLE
Retain empty arrays in links

### DIFF
--- a/lib/pmp/parser.rb
+++ b/lib/pmp/parser.rb
@@ -75,9 +75,7 @@ module PMP
         parse_links_list(info)
       elsif !info.is_a?(Array)
         Link.new(info)
-      # elsif info.size == 1
-      #   Link.new(info.first)
-      elsif info.size > 0        
+      else
         info.map{|l| Link.new(l)}
       end
     end

--- a/spec/collection_document_spec.rb
+++ b/spec/collection_document_spec.rb
@@ -74,7 +74,7 @@ describe PMP::CollectionDocument do
 
     it "should serialize to collection.doc+json" do
       @doc = PMP::CollectionDocument.new(document: json_fixture(:collection_basic))
-      @doc.to_json.must_equal '{"version":"1.0","links":{"profile":[{"href":"http://api-sandbox.pmp.io/profiles/story"}],"self":[{"href":"http://api-sandbox.pmp.io/docs/f84e9018-5c21-4b32-93f8-d519308620f0"}],"collection":[{"href":"http://api-sandbox.pmp.io/docs/"}]},"attributes":{"guid":"f84e9018-5c21-4b32-93f8-d519308620f0","title":"Peers Find Less Pressure Borrowing From Each Other","published":"2013-05-10T15:17:00.598Z","valid":{"from":"2013-05-10T15:17:00.598Z","to":"2213-05-10T15:17:00.598Z"},"byline":"by SOME PERSON","hreflang":"en","description":"","contentencoded":"...","contenttemplated":"..."}}'
+      @doc.to_json.must_equal '{"version":"1.0","links":{"profile":[{"href":"http://api-sandbox.pmp.io/profiles/story"}],"self":[{"href":"http://api-sandbox.pmp.io/docs/f84e9018-5c21-4b32-93f8-d519308620f0"}],"collection":[{"href":"http://api-sandbox.pmp.io/docs/"}],"queries":[],"edit-form":[]},"attributes":{"guid":"f84e9018-5c21-4b32-93f8-d519308620f0","title":"Peers Find Less Pressure Borrowing From Each Other","published":"2013-05-10T15:17:00.598Z","valid":{"from":"2013-05-10T15:17:00.598Z","to":"2213-05-10T15:17:00.598Z"},"byline":"by SOME PERSON","hreflang":"en","description":"","contentencoded":"...","contenttemplated":"..."}}'
     end
 
     it "provides list of attributes (not links)" do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -34,6 +34,12 @@ describe PMP::Parser do
     tc.links['self'].href.must_equal "http://api-sandbox.pmp.io/docs/f84e9018-5c21-4b32-93f8-d519308620f0"
   end
 
+  it "will parse empty arrays into empty arrays" do
+    tc = TestParser.new
+    tc.parse(json_fixture(:collection_links))
+    tc.links['edit-form'].must_equal Array.new
+  end
+
   it "will un-parse to hash for json serialization" do
     tc = TestParser.new
     tc.parse(json_fixture(:collection_basic))
@@ -41,7 +47,7 @@ describe PMP::Parser do
     # puts "basic as_json: #{hash}"
     hash.keys.sort.must_equal ['attributes', 'links', 'version']
     hash['attributes']['guid'].must_equal "f84e9018-5c21-4b32-93f8-d519308620f0"
-    hash['links'].keys.sort.must_equal ["collection", "profile", "self"]
+    hash['links'].keys.sort.must_equal ["collection", "edit-form", "profile", "queries", "self"]
   end
 
   it "parses query links into a hash based on rels" do


### PR DESCRIPTION
I should have brought this up before you pushed a new release this morning. Anyways, this commit will ensure that empty arrays are retained in the objects, providing a more consistent API to work with.
