### PR TITLE
Pin oauth2 gem to older working version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
   - 2.0
   - 2.1
-  - 2.5
 notifications:
   email:
     - andrew@prx.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
+  - 2.5
 notifications:
   email:
     - andrew@prx.org
-

--- a/lib/pmp/version.rb
+++ b/lib/pmp/version.rb
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
 
 module PMP
-  VERSION = '0.5.6'
+  VERSION = '0.5.7'
 end

--- a/pmp.gemspec
+++ b/pmp.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_development_dependency('bundler', '~> 1.3')
+  gem.add_development_dependency('bundler')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('minitest')
   gem.add_development_dependency('webmock')
@@ -32,8 +32,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('faraday')
   gem.add_runtime_dependency('faraday_middleware')
-  gem.add_runtime_dependency('oauth2')
-  gem.add_runtime_dependency('multi_json')
+  gem.add_runtime_dependency('oauth2', '~> 1.2.0')
   gem.add_runtime_dependency('excon')
   gem.add_runtime_dependency('hashie')
   gem.add_runtime_dependency('activesupport')

--- a/pmp.gemspec
+++ b/pmp.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('faraday')
   gem.add_runtime_dependency('faraday_middleware')
-  gem.add_runtime_dependency('oauth2', '~> 1.2.0')
+  gem.add_runtime_dependency('oauth2', '< 1.3.0')
   gem.add_runtime_dependency('excon')
   gem.add_runtime_dependency('hashie')
   gem.add_runtime_dependency('activesupport')


### PR DESCRIPTION
as a workaround for #9 at least pin to a working version, 1.2.0, while looking into how to fix this for more modern oauth2 clients